### PR TITLE
Add information on how geopera use's COGs in their workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,7 @@
 									<li><a href="http://rasterframes.io/">RasterFrames</a> brings the power of Spark DataFrames to geospatial raster data, and is able to read Cloud Optimized GeoTIFF's using <a href="http://geotrellis.io">GeoTrellis</a>.
 									<li><a href="http://farmshots.com/">Farmshots</a> builds agriculture analytics on top of Planet’s Cloud Optimized GeoTIFF’s, pulling in just the needed field data and serving it up live to their customers.</li>
 									<li><a href="https://eosda.com/">Earth Observing System</a>’s Engine and Land Viewer are both able to leverage Cloud Optimized GeoTIFFs for live web tile serving and on the fly band math.</li>
+									<li><a href="https://geopera.com/">Geopera</a>’s Imagery Portal utilizes Cloud Optimized GeoTIFFs for quick access to specific subsets of large datasets, reducing bandwith and allowing faster rendering and processing times.</li>
 									<li><a href="https://github.com/DHI-GRAS/terracotta">Terracotta</a> is a flexible, open-source tile server that you can use to view and serve your Cloud Optimized GeoTIFFs as web layers. Supports serverless architectures and serving COGs from S3 buckets.</li>
 									<li><a href="https://github.com/OpenDroneMap/WebODM">WebODM</a> is a user-friendly, extendable application and API for processing aerial imagery capable of serving Cloud Optimized GeoTIFFs.</li>
 									<li><a href="https://github.com/OpenDroneMap/ODM">ODM</a> is a command line toolkit to process aerial imagery and is capable of generating Cloud Optimized GeoTIFFs as 2D outputs.</li>


### PR DESCRIPTION
I have added a line in the list of Tools.

This briefly describes how Geopera uses COGs in their workflow within their portal. We also use COGs for a bit more than this and often deliver to customers in this format but I wanted to keep it concise.